### PR TITLE
feat: Automatically filter and reparent non-genAI spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The LangSmith Collector-Proxy addresses these issues by batching multiple spans 
 * **OTLP Support**: Accepts standard OpenTelemetry Protocol (OTLP) data in both JSON and Protocol Buffer formats via HTTP POST requests.
 * **Semantic Translation**: Converts GenAI semantic convention attributes to the LangSmith tracing model.
 * **Flexible Batching**: Configurable batching based on either the number of spans or a time interval.
+* **Span Filtering**: Filter spans based on configurable criteria to reduce noise and focus on relevant traces.
 
 ## Configuration
 
@@ -34,6 +35,7 @@ The Collector-Proxy can be customized via environment variables:
 | `MAX_BODY_BYTES`     | Maximum size of incoming request body          | `209715200` (200MB)               |
 | `MAX_RETRIES`        | Number of retry attempts for failed uploads    | `3`                               |
 | `RETRY_BACKOFF_MS`   | Initial backoff duration in milliseconds       | `100`                             |
+| `FILTER_NON_GENAI`   | Filter out non-GenAI spans (keeps only spans with `gen_ai.`, `langsmith.`, `llm.`, `ai.` prefixes) | `false` |
 
 ## Usage
 
@@ -59,6 +61,52 @@ To achieve this, you should:
 
 Failure to properly partition traces may result in incomplete or fragmented traces in LangSmith.
 
+## Span Filtering
+
+The Collector-Proxy supports automatically filtering spans to reduce noise and focus on relevant gen ai traces.
+
+### Built-in GenAI Filtering
+
+The proxy includes a built-in filter that keeps spans with names or attributes starting with:
+- `gen_ai.` - Standard GenAI semantic conventions
+- `langsmith.` - LangSmith-specific attributes
+- `llm.` - LLM-related spans
+- `ai.` - General AI-related spans
+
+### Tree Reparenting
+
+When spans are filtered, the proxy automatically maintains the trace hierarchy by:
+1. **Reparenting children**: Child spans of filtered spans are reparented to the closest non-filtered ancestor
+2. **Maintaining structure**: The trace tree structure is preserved even when intermediate spans are removed
+3. **Fallback to root**: If no valid parent is found, spans are attached to the trace root
+4. **Automatic dotted_order**: The aggregator automatically generates correct dotted_order values based on the new parent-child relationships
+
+### Usage Examples
+
+**Enable GenAI-only filtering via environment variable:**
+
+```bash
+# Enable GenAI filtering
+FILTER_NON_GENAI=true go run ./cmd/collector
+```
+
+**Custom filtering**
+If you need to filter spans based on custom criteria, you can use the `CustomFilter` option in the `FilterConfig` struct. In order to do so you will need to modify the code in the `cmd/collector/main.go` file.
+```go
+filterConfig := aggregator.FilterConfig{
+    FilterNonGenAI: false,
+    CustomFilter: func(run *model.Run) bool {
+        // Keep only runs that contain "important" in the name
+        return run.Name != nil && strings.Contains(*run.Name, "important")
+    },
+}
+```
+
+### Limitations
+
+- **Root span filtering**: If the root span of a trace is filtered out, its children may not be properly reparented and could be lost. It's recommended to avoid filtering root spans to maintain trace integrity. If you need to filter root spans, it is recommended to instead use the `langsmith.is_root` attribute to mark a span as a root span.
+
+- **Parent-child relationships**: The proxy automatically maintains the trace hierarchy by reparenting child spans of filtered spans to the closest non-filtered ancestor. This means you must send all spans of a trace to the same collector proxy instance in order to maintain the trace hierarchy and non preemptively filter spans. If the proxy is unable to reparent a span, it will become a root span.
 ## Monitoring and Health Checks
 
 The LangSmith Collector-Proxy exposes simple health-check endpoints:

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -35,6 +35,9 @@ func main() {
 		BatchSize:      cfg.BatchSize,
 		FlushInterval:  cfg.FlushInterval,
 		MaxBufferBytes: cfg.MaxBufferBytes,
+		FilterConfig: aggregator.FilterConfig{
+			FilterNonGenAI: cfg.FilterNonGenAI,
+		},
 	}, ch)
 	agg.Start()
 	defer agg.Stop()

--- a/internal/aggregator/filter_test.go
+++ b/internal/aggregator/filter_test.go
@@ -1,0 +1,434 @@
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-collector-proxy/internal/model"
+	"github.com/langchain-ai/langsmith-collector-proxy/internal/uploader"
+	"github.com/langchain-ai/langsmith-collector-proxy/internal/util"
+)
+
+func TestDefaultGenAIFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		run      *model.Run
+		expected bool
+	}{
+		{
+			name: "GenAI run name",
+			run: &model.Run{
+				Name: util.StringPtr("gen_ai.completion"),
+			},
+			expected: true,
+		},
+		{
+			name: "LangSmith run name",
+			run: &model.Run{
+				Name: util.StringPtr("langsmith.trace"),
+			},
+			expected: true,
+		},
+		{
+			name: "LLM run name",
+			run: &model.Run{
+				Name: util.StringPtr("llm.openai"),
+			},
+			expected: true,
+		},
+		{
+			name: "GenAI attribute in Extra",
+			run: &model.Run{
+				Name: util.StringPtr("regular_run"),
+				Extra: map[string]interface{}{
+					"gen_ai.system": "openai",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Non-GenAI run",
+			run: &model.Run{
+				Name: util.StringPtr("http.request"),
+				Extra: map[string]interface{}{
+					"http.method": "GET",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "AI attribute prefix",
+			run: &model.Run{
+				Name: util.StringPtr("regular_run"),
+				Extra: map[string]interface{}{
+					"ai.model_name": "gpt-4",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DefaultGenAIFilter(tt.run)
+			if result != tt.expected {
+				t.Errorf("DefaultGenAIFilter() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFilterConfig_ShouldKeepRun(t *testing.T) {
+	genAIRun := &model.Run{
+		Name: util.StringPtr("gen_ai.completion"),
+	}
+
+	nonGenAIRun := &model.Run{
+		Name: util.StringPtr("http.request"),
+	}
+
+	tests := []struct {
+		name     string
+		config   FilterConfig
+		run      *model.Run
+		expected bool
+	}{
+		{
+			name:     "No filtering - keep all",
+			config:   FilterConfig{FilterNonGenAI: false, CustomFilter: nil},
+			run:      nonGenAIRun,
+			expected: true,
+		},
+		{
+			name:     "Filter non-GenAI - keep GenAI run",
+			config:   FilterConfig{FilterNonGenAI: true, CustomFilter: nil},
+			run:      genAIRun,
+			expected: true,
+		},
+		{
+			name:     "Filter non-GenAI - discard non-GenAI run",
+			config:   FilterConfig{FilterNonGenAI: true, CustomFilter: nil},
+			run:      nonGenAIRun,
+			expected: false,
+		},
+		{
+			name: "Custom filter - keep only http runs",
+			config: FilterConfig{
+				FilterNonGenAI: false,
+				CustomFilter: func(run *model.Run) bool {
+					return run.Name != nil && *run.Name == "http.request"
+				},
+			},
+			run:      nonGenAIRun,
+			expected: true,
+		},
+		{
+			name: "Custom filter - discard GenAI runs",
+			config: FilterConfig{
+				FilterNonGenAI: false,
+				CustomFilter: func(run *model.Run) bool {
+					return run.Name != nil && *run.Name == "http.request"
+				},
+			},
+			run:      genAIRun,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.config.ShouldKeepRun(tt.run)
+			if result != tt.expected {
+				t.Errorf("ShouldKeepRun() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTreeReparenting(t *testing.T) {
+	// Test the scenario: root -> parent -> filtered -> child
+	// Expected: root -> parent -> child (filtered span removed, child reparented to parent)
+	
+	mockUploader := uploader.New(uploader.Config{
+		BaseURL:     "http://localhost",
+		APIKey:      "test-key",
+		MaxAttempts: 1,
+		InFlight:    1,
+	})
+	
+	cfg := Config{
+		BatchSize:     10,
+		FlushInterval: 200 * time.Millisecond,
+		FilterConfig: FilterConfig{
+			FilterNonGenAI: true,
+		},
+	}
+
+	ch := make(chan *model.Run, 10)
+	agg := New(mockUploader, cfg, ch)
+	agg.Start()
+	defer agg.Stop()
+
+	// Send runs in order: root -> genai_parent -> http_filtered -> genai_child
+	rootRun := &model.Run{
+		ID:      util.StringPtr("root-id"),
+		TraceID: util.StringPtr("trace-id"),
+		Name:    util.StringPtr("gen_ai.root"),
+	}
+
+	genaiParent := &model.Run{
+		ID:          util.StringPtr("genai-parent-id"),
+		TraceID:     util.StringPtr("trace-id"),
+		ParentRunID: util.StringPtr("root-id"),
+		Name:        util.StringPtr("gen_ai.parent"),
+	}
+
+	httpFiltered := &model.Run{
+		ID:          util.StringPtr("http-filtered-id"),
+		TraceID:     util.StringPtr("trace-id"),
+		ParentRunID: util.StringPtr("genai-parent-id"),
+		Name:        util.StringPtr("http.request"), // Should be filtered
+	}
+
+	genaiChild := &model.Run{
+		ID:          util.StringPtr("genai-child-id"),
+		TraceID:     util.StringPtr("trace-id"),
+		ParentRunID: util.StringPtr("http-filtered-id"), // Parent will be filtered
+		Name:        util.StringPtr("gen_ai.child"),
+	}
+
+	// Send runs
+	ch <- rootRun
+	time.Sleep(10 * time.Millisecond)
+	ch <- genaiParent
+	time.Sleep(10 * time.Millisecond)
+	ch <- httpFiltered
+	time.Sleep(10 * time.Millisecond)
+	ch <- genaiChild
+
+	// Wait for processing
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify filtered run is tracked
+	if _, exists := agg.filteredIDs.Load("http-filtered-id"); !exists {
+		t.Error("Expected filtered run ID to be tracked")
+	}
+
+	// Verify kept runs are not marked as filtered
+	if _, exists := agg.filteredIDs.Load("root-id"); exists {
+		t.Error("Expected root run not to be marked as filtered")
+	}
+	if _, exists := agg.filteredIDs.Load("genai-parent-id"); exists {
+		t.Error("Expected GenAI parent run not to be marked as filtered")
+	}
+	if _, exists := agg.filteredIDs.Load("genai-child-id"); exists {
+		t.Error("Expected GenAI child run not to be marked as filtered")
+	}
+}
+
+func TestMultiLevelFiltering(t *testing.T) {
+	// Test scenario: root -> filtered1 -> filtered2 -> child
+	// Expected: root -> child (both intermediate spans filtered, child reparented to root)
+	
+	mockUploader := uploader.New(uploader.Config{
+		BaseURL:     "http://localhost",
+		APIKey:      "test-key",
+		MaxAttempts: 1,
+		InFlight:    1,
+	})
+	
+	cfg := Config{
+		BatchSize:     10,
+		FlushInterval: 200 * time.Millisecond,
+		FilterConfig: FilterConfig{
+			FilterNonGenAI: true,
+		},
+	}
+
+	ch := make(chan *model.Run, 10)
+	agg := New(mockUploader, cfg, ch)
+	agg.Start()
+	defer agg.Stop()
+
+	runs := []*model.Run{
+		{
+			ID:      util.StringPtr("root-id"),
+			TraceID: util.StringPtr("trace-id"),
+			Name:    util.StringPtr("gen_ai.root"),
+		},
+		{
+			ID:          util.StringPtr("filtered1-id"),
+			TraceID:     util.StringPtr("trace-id"),
+			ParentRunID: util.StringPtr("root-id"),
+			Name:        util.StringPtr("http.request1"), // Filtered
+		},
+		{
+			ID:          util.StringPtr("filtered2-id"),
+			TraceID:     util.StringPtr("trace-id"),
+			ParentRunID: util.StringPtr("filtered1-id"),
+			Name:        util.StringPtr("http.request2"), // Filtered
+		},
+		{
+			ID:          util.StringPtr("child-id"),
+			TraceID:     util.StringPtr("trace-id"),
+			ParentRunID: util.StringPtr("filtered2-id"),
+			Name:        util.StringPtr("gen_ai.child"),
+		},
+	}
+
+	// Send all runs
+	for _, run := range runs {
+		ch <- run
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Wait for processing
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify both filtered runs are tracked
+	if _, exists := agg.filteredIDs.Load("filtered1-id"); !exists {
+		t.Error("Expected first filtered run to be tracked")
+	}
+	if _, exists := agg.filteredIDs.Load("filtered2-id"); !exists {
+		t.Error("Expected second filtered run to be tracked")
+	}
+
+	// Verify kept runs are not filtered
+	if _, exists := agg.filteredIDs.Load("root-id"); exists {
+		t.Error("Expected root run not to be marked as filtered")
+	}
+	if _, exists := agg.filteredIDs.Load("child-id"); exists {
+		t.Error("Expected child run not to be marked as filtered")
+	}
+}
+
+func TestOutOfOrderArrival(t *testing.T) {
+	// Test cross-request scenario: child arrives before filtered parent
+	
+	mockUploader := uploader.New(uploader.Config{
+		BaseURL:     "http://localhost",
+		APIKey:      "test-key",
+		MaxAttempts: 1,
+		InFlight:    1,
+	})
+	
+	cfg := Config{
+		BatchSize:     10,
+		FlushInterval: 200 * time.Millisecond,
+		FilterConfig: FilterConfig{
+			FilterNonGenAI: true,
+		},
+	}
+
+	ch := make(chan *model.Run, 10)
+	agg := New(mockUploader, cfg, ch)
+	agg.Start()
+	defer agg.Stop()
+
+	// Send child first (it will wait for parent)
+	genaiChild := &model.Run{
+		ID:          util.StringPtr("genai-child-id"),
+		TraceID:     util.StringPtr("trace-id"),
+		ParentRunID: util.StringPtr("filtered-parent-id"),
+		Name:        util.StringPtr("gen_ai.child"),
+	}
+	ch <- genaiChild
+	time.Sleep(50 * time.Millisecond)
+
+	// Send root
+	rootRun := &model.Run{
+		ID:      util.StringPtr("root-id"),
+		TraceID: util.StringPtr("trace-id"),
+		Name:    util.StringPtr("gen_ai.root"),
+	}
+	ch <- rootRun
+	time.Sleep(10 * time.Millisecond)
+
+	// Send filtered parent (this should trigger reparenting of waiting child)
+	filteredParent := &model.Run{
+		ID:          util.StringPtr("filtered-parent-id"),
+		TraceID:     util.StringPtr("trace-id"),
+		ParentRunID: util.StringPtr("root-id"),
+		Name:        util.StringPtr("http.request"), // Will be filtered
+	}
+	ch <- filteredParent
+
+	// Wait for processing
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify filtered parent is tracked
+	if _, exists := agg.filteredIDs.Load("filtered-parent-id"); !exists {
+		t.Error("Expected filtered parent to be tracked")
+	}
+
+	// Child should not be filtered
+	if _, exists := agg.filteredIDs.Load("genai-child-id"); exists {
+		t.Error("Expected child not to be marked as filtered")
+	}
+}
+
+func TestCustomFilter(t *testing.T) {
+	mockUploader := uploader.New(uploader.Config{
+		BaseURL:     "http://localhost",
+		APIKey:      "test-key",
+		MaxAttempts: 1,
+		InFlight:    1,
+	})
+	
+	cfg := Config{
+		BatchSize:     10,
+		FlushInterval: 200 * time.Millisecond,
+		FilterConfig: FilterConfig{
+			FilterNonGenAI: false,
+			CustomFilter: func(run *model.Run) bool {
+				// Keep only runs with "important" in name
+				return run.Name != nil && (*run.Name == "important.task" || *run.Name == "gen_ai.completion")
+			},
+		},
+	}
+
+	ch := make(chan *model.Run, 10)
+	agg := New(mockUploader, cfg, ch)
+	agg.Start()
+	defer agg.Stop()
+
+	runs := []*model.Run{
+		{
+			ID:      util.StringPtr("root-id"),
+			TraceID: util.StringPtr("trace-id"),
+			Name:    util.StringPtr("important.task"),
+		},
+		{
+			ID:          util.StringPtr("filtered-id"),
+			TraceID:     util.StringPtr("trace-id"),
+			ParentRunID: util.StringPtr("root-id"),
+			Name:        util.StringPtr("regular.task"), // Will be filtered by custom filter
+		},
+		{
+			ID:          util.StringPtr("child-id"),
+			TraceID:     util.StringPtr("trace-id"),
+			ParentRunID: util.StringPtr("filtered-id"),
+			Name:        util.StringPtr("gen_ai.completion"),
+		},
+	}
+
+	for _, run := range runs {
+		ch <- run
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify custom filtering worked
+	if _, exists := agg.filteredIDs.Load("filtered-id"); !exists {
+		t.Error("Expected custom filtered run to be tracked")
+	}
+
+	if _, exists := agg.filteredIDs.Load("root-id"); exists {
+		t.Error("Expected important task not to be filtered")
+	}
+
+	if _, exists := agg.filteredIDs.Load("child-id"); exists {
+		t.Error("Expected gen_ai.completion not to be filtered")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -17,6 +18,7 @@ type Config struct {
 	MaxBufferBytes int
 	MaxRetries     int
 	BackoffInitial time.Duration
+	FilterNonGenAI bool
 }
 
 func env(key, def string) string {
@@ -31,6 +33,13 @@ func envInt64(key string, def int64) int64 {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
 			return n
 		}
+	}
+	return def
+}
+
+func envBool(key string, def bool) bool {
+	if v := os.Getenv(key); v != "" {
+		return strings.ToLower(v) == "true"
 	}
 	return def
 }
@@ -57,5 +66,7 @@ func Load() Config {
 		// Uploader Config
 		MaxRetries:     int(envInt64("MAX_RETRIES", 3)),
 		BackoffInitial: time.Duration(envInt64("RETRY_BACKOFF_MS", 100)) * time.Millisecond,
+		// Filter Config
+		FilterNonGenAI: envBool("FILTER_NON_GENAI", false),
 	}
 }

--- a/internal/translator/otel_converter.go
+++ b/internal/translator/otel_converter.go
@@ -62,6 +62,7 @@ const (
 	LangSmithTags               = "langsmith.span.tags"
 	LangSmithUsageMetadata      = "langsmith.usage_metadata"
 	LangSmithReferenceExampleID = "langsmith.reference_example_id"
+	LangSmithRoot               = "langsmith.is_root"
 
 	// LangSmith, see: https://docs.smith.langchain.com/observability/how_to_guides/tracing/log_llm_trace
 	LangSmithInvocationParams = "invocation_params"
@@ -171,7 +172,8 @@ func initializeRun(ctx *spanContext) (*model.Run, error) {
 	}
 
 	var parentID *string
-	if len(ctx.span.ParentSpanId) > 0 {
+	isLangSmithRoot := getStringValue(ctx.attrs, LangSmithRoot) == "true"
+	if !isLangSmithRoot && len(ctx.span.ParentSpanId) > 0 {
 		parsed, err := idToUUID(ctx.span.ParentSpanId)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Summary

  - Add configurable span filtering for GenAI traces
  - Implement automatic tree reparenting to maintain trace hierarchy when spans are filtered
  - Add FILTER_NON_GENAI environment variable to enable built-in GenAI filtering

 ###  Features
  - Built-in GenAI Filter: Keeps spans with gen_ai., langsmith., llm., or ai. prefixes
  - Smart Reparenting: Child spans of filtered spans are automatically reparented to the closest non-filtered ancestor
  - Custom Filtering: Support for custom filter functions in code
  - Trace Integrity: Maintains proper trace structure even when intermediate spans are removed