### PR TITLE
fix: Correctly reparent traces after filtering

### DIFF
--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -259,7 +259,7 @@ func (a *Aggregator) worker(ctx context.Context, ch <-chan *model.Run) {
 				newParentID := a.findValidParent(*r.ParentRunID, parentByRunID)
 				if newParentID != *r.ParentRunID {
 					if newParentID == "" {
-						r.ParentRunID = nil
+						r.ParentRunID = r.TraceID
 					} else {
 						r.ParentRunID = &newParentID
 					}
@@ -337,7 +337,7 @@ func (a *Aggregator) reparentChildrenOfFiltered(
 			// Find valid grandparent for this child
 			newParentID := a.findValidParent(*child.ParentRunID, parentByRunID)
 			if newParentID == "" {
-				child.ParentRunID = nil
+				child.ParentRunID = child.TraceID
 			} else {
 				child.ParentRunID = &newParentID
 			}

--- a/internal/translator/otel_converter.go
+++ b/internal/translator/otel_converter.go
@@ -172,7 +172,7 @@ func initializeRun(ctx *spanContext) (*model.Run, error) {
 	}
 
 	var parentID *string
-	isLangSmithRoot := getStringValue(ctx.attrs, LangSmithRoot) == "true"
+	isLangSmithRoot := getBoolValue(ctx.attrs, LangSmithRoot)
 	if !isLangSmithRoot && len(ctx.span.ParentSpanId) > 0 {
 		parsed, err := idToUUID(ctx.span.ParentSpanId)
 		if err != nil {
@@ -745,6 +745,15 @@ func getIntValue(attrs map[string]*commonpb.AnyValue, key string) *int64 {
 		}
 	}
 	return nil
+}
+
+func getBoolValue(attrs map[string]*commonpb.AnyValue, key string) bool {
+	if attr, ok := attrs[key]; ok {
+		if v, ok := attr.Value.(*commonpb.AnyValue_BoolValue); ok {
+			return v.BoolValue
+		}
+	}
+	return false
 }
 
 func getAttrValue(attrs map[string]*commonpb.AnyValue, key string) interface{} {


### PR DESCRIPTION
Traces that couldn't find a parent would be discarded instead of being attached to the trace id, this had the effect of incorrectly filtering spans, and incorrectly rerooting traces when using `langsmith.is_root`